### PR TITLE
Fix config Writing

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -15,7 +16,10 @@ var logoutCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("deleted authentication token")
 		viper.Set("token", "")
-		viper.WriteConfigAs(utils.GetConfigFile())
+		err := viper.WriteConfigAs(utils.GetConfigFile())
+		if err != nil {
+			log.Fatalf("cannot write config to %s: %v", utils.GetConfigFile(), err)
+		}
 	},
 }
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -27,7 +28,10 @@ var setCmd = &cobra.Command{
 			value, _ := cmd.Flags().GetString(flag)
 			if value != "" {
 				viper.BindPFlag(flag, cmd.Flags().Lookup(flag))
-				viper.WriteConfigAs(utils.GetConfigFile())
+				err := viper.WriteConfigAs(utils.GetConfigFile())
+				if err != nil {
+					log.Fatalf("cannot write config to %s: %v", utils.GetConfigFile(), err)
+				}
 				fmt.Printf("Saved %s to %s\n", flag, utils.GetConfigFile())
 			}
 		}

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -26,7 +26,7 @@ func CheckTokenExists() bool {
 // SaveToken saves the API Access Token to the config file for re-use
 func SaveToken(token string) {
 	viper.Set("token", token)
-	viper.WriteConfigAs(utils.GetConfigPath())
+	viper.WriteConfigAs(utils.GetConfigFile())
 }
 
 // GetToken retrieves client ID, client secret, and localhost port, and implements

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -26,7 +26,10 @@ func CheckTokenExists() bool {
 // SaveToken saves the API Access Token to the config file for re-use
 func SaveToken(token string) {
 	viper.Set("token", token)
-	viper.WriteConfigAs(utils.GetConfigFile())
+	err := viper.WriteConfigAs(utils.GetConfigFile())
+	if err != nil {
+		log.Fatalf("cannot write config to %s: %v", utils.GetConfigFile(), err)
+	}
 }
 
 // GetToken retrieves client ID, client secret, and localhost port, and implements


### PR DESCRIPTION
## Description
- Adds error checking for failed config writing
- Fixes previous writing of token to a `utils.GetConfigPath` instead of `utils.GetConfigFile`

![image](https://user-images.githubusercontent.com/14822949/150442646-3b456751-8369-4659-bf68-4858a031a04b.png)
